### PR TITLE
Replaced 100% battery icon 

### DIFF
--- a/quickshell/modules/battery/BatteryWidget.qml
+++ b/quickshell/modules/battery/BatteryWidget.qml
@@ -27,7 +27,7 @@ Rectangle {
             if (batteryPercentage >= 10)  return "󰢜"
             return "󰢟"
         } else {
-            if (batteryPercentage >= 100) return "󰂂"
+            if (batteryPercentage >= 100) return "󰁹"
             if (batteryPercentage >= 90)  return "󰂂"
             if (batteryPercentage >= 80)  return "󰂁"
             if (batteryPercentage >= 70)  return "󰂀"


### PR DESCRIPTION
Replaced the battery icon with the right one when not charging and at 100%.